### PR TITLE
Save float instead of torch tensor

### DIFF
--- a/train.py
+++ b/train.py
@@ -347,7 +347,7 @@ def main():
                 if not opt.continue_training:
                     writer.writerow(['Epoch', 'Iteration', 'Time', 'Loss', 'LossEpoch', 'ValidLossEpoch', 'Alpha', 'AlphaEpoch', 'Beta'])
                 def log_func(epoch, iteration, time_spent, loss, loss_epoch, valid_loss, alpha, alpha_epoch, beta):
-                    writer.writerow([epoch, iteration, time_spent, loss, loss_epoch, valid_loss, alpha, alpha_epoch, beta])
+                    writer.writerow([epoch, iteration, time_spent, loss.item(), loss_epoch, valid_loss, alpha.item(), alpha_epoch, beta])
                     if not opt.silent:
                         print('{} | {} | Epoch: {} | Iter: {} | Time: {:+.3e} | Loss: {:+.3e} | Valid. loss: {:+.3e} | Alpha: {:+.3e} | Beta: {:+.3e}'.format(opt.model, opt.method, epoch, iteration, time_spent, loss, valid_loss, alpha, beta))
                 train(opt, log_func)


### PR DESCRIPTION
Currently, loss and alpha is saved as it is (which is either a torch tensor or torch.cuda tensor) which is difficult for post-processing and analysing loss